### PR TITLE
Fixed broken link to Sal docs page.

### DIFF
--- a/unauthorisedadmins/README.md
+++ b/unauthorisedadmins/README.md
@@ -4,4 +4,4 @@ This plugin will show machines that have admin users that aren't defined in ``se
 
 ``AUTHORISED_ADMINS = [ 'someadminuser', 'anotheradminuser']``
 
-This plugin requires the ``mac_admin_users`` fact from [mac_facts](https://github.com/grahamgilbert/grahamgilbert-mac_facts) to be installed as per the [Sal documentation](https://github.com/grahamgilbert/sal/blob/master/docs/Installation.md).
+This plugin requires the ``mac_admin_users`` fact from [mac_facts](https://github.com/grahamgilbert/grahamgilbert-mac_facts) to be installed as per the [Sal documentation](https://github.com/salopensource/sal/wiki/Installing-and-using-plugins).


### PR DESCRIPTION
Currently links to https://github.com/grahamgilbert/sal/blob/master/docs/Installation.md, changed to https://github.com/salopensource/sal/wiki/Installing-and-using-plugins